### PR TITLE
If ByteArrayDeserializer gets an empty array, return null instead of calling Activator.CreateInstance

### DIFF
--- a/Activout.RestClient.Newtonsoft.Json.Test/RestClientTests.cs
+++ b/Activout.RestClient.Newtonsoft.Json.Test/RestClientTests.cs
@@ -482,6 +482,24 @@ namespace Activout.RestClient.Newtonsoft.Json.Test
         }
 
         [Fact]
+        public async Task TestGetEmptyByteArray()
+        {
+            // arrange
+            _mockHttp
+                .When($"{BaseUri}/movies/bytes")
+                .Respond(new ByteArrayContent(new byte[0]));
+
+            var reviewSvc = CreateMovieReviewService();
+
+            // act
+            var bytes = await reviewSvc.GetByteArray();
+
+            // assert
+            Assert.NotNull(bytes);
+            Assert.Empty(bytes);
+        }
+
+        [Fact]
         public async Task TestGetByteArrayObject()
         {
             // arrange
@@ -496,6 +514,23 @@ namespace Activout.RestClient.Newtonsoft.Json.Test
 
             // assert
             Assert.Equal(new byte[] { 42 }, byteArrayObject.Bytes);
+        }
+
+        [Fact]
+        public async Task TestGetByteArrayObjectWithEmptyArray()
+        {
+            // arrange
+            _mockHttp
+                .When($"{BaseUri}/movies/byte-object")
+                .Respond(new ByteArrayContent(new byte[0]));
+
+            var reviewSvc = CreateMovieReviewService();
+
+            // act
+            var byteArrayObject = await reviewSvc.GetByteArrayObject();
+
+            // assert
+            Assert.Null(byteArrayObject);
         }
 
         [Fact]

--- a/Activout.RestClient/Serialization/Implementation/ByteArrayDeserializer.cs
+++ b/Activout.RestClient/Serialization/Implementation/ByteArrayDeserializer.cs
@@ -19,6 +19,11 @@ namespace Activout.RestClient.Serialization.Implementation
         {
             var bytes = await content.ReadAsByteArrayAsync();
 
+            if (bytes.Length == 0)
+            {
+                return type == typeof(byte[]) ? bytes : null;
+            }
+
             return type == typeof(byte[])
                 ? bytes
                 : Activator.CreateInstance(type, bytes);


### PR DESCRIPTION

TODO: Maybe make this behavior configurable before merge?

Resolves #22